### PR TITLE
Patch various array index errors

### DIFF
--- a/lib/nas/nas_ies.c
+++ b/lib/nas/nas_ies.c
@@ -1590,6 +1590,8 @@ c_int16_t nas_decode_emergency_number_list(nas_emergency_number_list_t *emergenc
     emergency_number_list->length = source->length;
     size = emergency_number_list->length + sizeof(emergency_number_list->length);
 
+    d_assert(emergency_number_list->length <= NAS_MAX_EMERGENCY_NUMBER_LIST_LEN, return -1, "pkbuf_header error");
+
     d_assert(pkbuf_header(pkbuf, -size) == CORE_OK, return -1, "pkbuf_header error");
     memcpy(emergency_number_list, pkbuf->payload - size, size);
 

--- a/lib/s1ap/asn1c/S1AP_ProtocolExtensionField.c
+++ b/lib/s1ap/asn1c/S1AP_ProtocolExtensionField.c
@@ -13781,6 +13781,15 @@ static asn_TYPE_member_t asn_MBR_S1AP_extensionValue_104[] = {
 		0, 0, /* No default value */
 		"COUNTValueExtended"
 		},
+	{ ATF_NOFLAGS, 0, offsetof(struct S1AP_Bearers_SubjectToStatusTransfer_ItemExtIEs__extensionValue, choice.COUNTValueExtended),
+		(ASN_TAG_CLASS_UNIVERSAL | (16 << 2)),
+		0,
+		&asn_DEF_S1AP_COUNTValueExtended,
+		0,
+		{ 0, 0, 0 },
+		0, 0, /* No default value */
+		"COUNTValueExtended"
+		},
 	{ ATF_NOFLAGS, 0, offsetof(struct S1AP_Bearers_SubjectToStatusTransfer_ItemExtIEs__extensionValue, choice.ReceiveStatusOfULPDCPSDUsExtended),
 		(ASN_TAG_CLASS_UNIVERSAL | (3 << 2)),
 		0,
@@ -13789,6 +13798,15 @@ static asn_TYPE_member_t asn_MBR_S1AP_extensionValue_104[] = {
 		{ 0, 0, 0 },
 		0, 0, /* No default value */
 		"ReceiveStatusOfULPDCPSDUsExtended"
+		},
+	{ ATF_NOFLAGS, 0, offsetof(struct S1AP_Bearers_SubjectToStatusTransfer_ItemExtIEs__extensionValue, choice.COUNTvaluePDCP_SNlength18),
+		(ASN_TAG_CLASS_UNIVERSAL | (16 << 2)),
+		0,
+		&asn_DEF_S1AP_COUNTvaluePDCP_SNlength18,
+		0,
+		{ 0, 0, 0 },
+		0, 0, /* No default value */
+		"COUNTvaluePDCP-SNlength18"
 		},
 	{ ATF_NOFLAGS, 0, offsetof(struct S1AP_Bearers_SubjectToStatusTransfer_ItemExtIEs__extensionValue, choice.COUNTvaluePDCP_SNlength18),
 		(ASN_TAG_CLASS_UNIVERSAL | (16 << 2)),

--- a/lib/s1ap/asn1c/S1AP_ProtocolIE-Field.c
+++ b/lib/s1ap/asn1c/S1AP_ProtocolIE-Field.c
@@ -22730,6 +22730,15 @@ static asn_TYPE_member_t asn_MBR_S1AP_value_76[] = {
 		0, 0, /* No default value */
 		"Source-ToTarget-TransparentContainer"
 		},
+	{ ATF_NOFLAGS, 0, offsetof(struct S1AP_HandoverRequiredIEs__value, choice.Source_ToTarget_TransparentContainer),
+		(ASN_TAG_CLASS_UNIVERSAL | (4 << 2)),
+		0,
+		&asn_DEF_S1AP_Source_ToTarget_TransparentContainer,
+		0,
+		{ 0, 0, 0 },
+		0, 0, /* No default value */
+		"Source-ToTarget-TransparentContainer"
+		},
 	{ ATF_NOFLAGS, 0, offsetof(struct S1AP_HandoverRequiredIEs__value, choice.MSClassmark2),
 		(ASN_TAG_CLASS_UNIVERSAL | (4 << 2)),
 		0,
@@ -22940,6 +22949,15 @@ static asn_TYPE_member_t asn_MBR_S1AP_value_80[] = {
 		{ 0, 0, 0 },
 		0, 0, /* No default value */
 		"E-RABList"
+		},
+	{ ATF_NOFLAGS, 0, offsetof(struct S1AP_HandoverCommandIEs__value, choice.Target_ToSource_TransparentContainer),
+		(ASN_TAG_CLASS_UNIVERSAL | (4 << 2)),
+		0,
+		&asn_DEF_S1AP_Target_ToSource_TransparentContainer,
+		0,
+		{ 0, 0, 0 },
+		0, 0, /* No default value */
+		"Target-ToSource-TransparentContainer"
 		},
 	{ ATF_NOFLAGS, 0, offsetof(struct S1AP_HandoverCommandIEs__value, choice.Target_ToSource_TransparentContainer),
 		(ASN_TAG_CLASS_UNIVERSAL | (4 << 2)),
@@ -23340,6 +23358,15 @@ static asn_TYPE_member_t asn_MBR_S1AP_value_88[] = {
 		{ 0, 0, 0 },
 		0, 0, /* No default value */
 		"GUMMEI"
+		},
+	{ ATF_NOFLAGS, 0, offsetof(struct S1AP_HandoverRequestIEs__value, choice.MME_UE_S1AP_ID),
+		(ASN_TAG_CLASS_UNIVERSAL | (2 << 2)),
+		0,
+		&asn_DEF_S1AP_MME_UE_S1AP_ID,
+		0,
+		{ 0, 0, 0 },
+		0, 0, /* No default value */
+		"MME-UE-S1AP-ID"
 		},
 	{ ATF_NOFLAGS, 0, offsetof(struct S1AP_HandoverRequestIEs__value, choice.ManagementBasedMDTAllowed),
 		(ASN_TAG_CLASS_UNIVERSAL | (10 << 2)),
@@ -24292,6 +24319,15 @@ static asn_TYPE_member_t asn_MBR_S1AP_value_108[] = {
 		{ 0, 0, 0 },
 		0, 0, /* No default value */
 		"CriticalityDiagnostics"
+		},
+	{ ATF_NOFLAGS, 0, offsetof(struct S1AP_PathSwitchRequestAcknowledgeIEs__value, choice.MME_UE_S1AP_ID),
+		(ASN_TAG_CLASS_UNIVERSAL | (2 << 2)),
+		0,
+		&asn_DEF_S1AP_MME_UE_S1AP_ID,
+		0,
+		{ 0, 0, 0 },
+		0, 0, /* No default value */
+		"MME-UE-S1AP-ID"
 		},
 	{ ATF_NOFLAGS, 0, offsetof(struct S1AP_PathSwitchRequestAcknowledgeIEs__value, choice.CSGMembershipStatus),
 		(ASN_TAG_CLASS_UNIVERSAL | (10 << 2)),
@@ -25931,6 +25967,15 @@ static asn_TYPE_member_t asn_MBR_S1AP_value_152[] = {
 		{ 0, 0, 0 },
 		0, 0, /* No default value */
 		"GUMMEI"
+		},
+	{ ATF_NOFLAGS, 0, offsetof(struct S1AP_InitialContextSetupRequestIEs__value, choice.MME_UE_S1AP_ID),
+		(ASN_TAG_CLASS_UNIVERSAL | (2 << 2)),
+		0,
+		&asn_DEF_S1AP_MME_UE_S1AP_ID,
+		0,
+		{ 0, 0, 0 },
+		0, 0, /* No default value */
+		"MME-UE-S1AP-ID"
 		},
 	{ ATF_NOFLAGS, 0, offsetof(struct S1AP_InitialContextSetupRequestIEs__value, choice.ManagementBasedMDTAllowed),
 		(ASN_TAG_CLASS_UNIVERSAL | (10 << 2)),
@@ -34085,6 +34130,15 @@ static asn_TYPE_member_t asn_MBR_S1AP_value_388[] = {
 		{ 0, 0, 0 },
 		0, 0, /* No default value */
 		"E-RABModifyListBearerModConf"
+		},
+	{ ATF_NOFLAGS, 0, offsetof(struct S1AP_E_RABModificationConfirmIEs__value, choice.E_RABList),
+		(ASN_TAG_CLASS_UNIVERSAL | (16 << 2)),
+		0,
+		&asn_DEF_S1AP_E_RABList,
+		0,
+		{ 0, 0, 0 },
+		0, 0, /* No default value */
+		"E-RABList"
 		},
 	{ ATF_NOFLAGS, 0, offsetof(struct S1AP_E_RABModificationConfirmIEs__value, choice.E_RABList),
 		(ASN_TAG_CLASS_UNIVERSAL | (16 << 2)),

--- a/src/mme/mme_context.c
+++ b/src/mme/mme_context.c
@@ -2320,6 +2320,9 @@ mme_ue_t* mme_ue_find_by_message(nas_message_t *message)
                 {
                     c_int8_t imsi_bcd[MAX_IMSI_BCD_LEN+1];
 
+                    if (eps_mobile_identity->length > MAX_IMSI_BCD_LEN+1) {
+                        break;
+                    }
                     nas_imsi_to_bcd(
                         &eps_mobile_identity->imsi, eps_mobile_identity->length,
                         imsi_bcd);


### PR DESCRIPTION
Resolves several issues in ASN.1 decoding and parsing of S1AP/NAS payloads that could crash the MME if invalid inputs are received by untrusted devices.